### PR TITLE
image/remove: emulate docker's untagging

### DIFF
--- a/pkg/client/image/remove.go
+++ b/pkg/client/image/remove.go
@@ -14,14 +14,23 @@ type Remove struct {
 }
 
 func (s *Remove) Do(ctx context.Context, k8s *client.Interface, image string) error {
-	if named, err := reference.ParseNormalizedNamed(image); err == nil {
-		image = named.String()
-	}
 	return client.Images(ctx, k8s, func(ctx context.Context, imagesClient imagesv1.ImagesClient) error {
 		req := &imagesv1.ImageRemoveRequest{
 			Image: &criv1.ImageSpec{
 				Image: image,
 			},
+		}
+		if ref, err := reference.ParseAnyReference(image); err == nil {
+			statusRequest := imagesv1.ImageStatusRequest{
+				Image: &criv1.ImageSpec{
+					Image: ref.String(),
+				},
+			}
+			statusResponse, err := imagesClient.Status(ctx, &statusRequest)
+			logrus.Debugf("%#v", statusResponse.Image)
+			if err == nil && statusResponse.Image != nil {
+				req.Image = statusRequest.Image
+			}
 		}
 		res, err := imagesClient.Remove(ctx, req)
 		if err != nil {

--- a/pkg/server/images/remove.go
+++ b/pkg/server/images/remove.go
@@ -3,13 +3,27 @@ package images
 import (
 	"context"
 
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
 	imagesv1 "github.com/rancher/kim/pkg/apis/services/images/v1alpha1"
+	"github.com/sirupsen/logrus"
 	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // Remove image server-side impl
 func (s *Server) Remove(ctx context.Context, req *imagesv1.ImageRemoveRequest) (*imagesv1.ImageRemoveResponse, error) {
-	_, err := s.ImageService().RemoveImage(ctx, &criv1.RemoveImageRequest{Image: req.Image})
+	logrus.Debugf("image-remove: %#v", req.Image)
+	ctx, done, err := s.Containerd.WithLease(namespaces.WithNamespace(ctx, "k8s.io"))
+	if err != nil {
+		return nil, err
+	}
+	defer done(ctx)
+	err = s.Containerd.ImageService().Delete(ctx, req.Image.Image, images.SynchronousDelete())
+	if errdefs.IsNotFound(err) {
+		// at this point we assume it is an image id and fallback to cri behavior, aka remove every tag/digest
+		_, err = s.ImageService().RemoveImage(ctx, &criv1.RemoveImageRequest{Image: req.Image})
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When the Docker CLI removes an image:tag it effectively removes the tag.
This change emulates such behavior but will fallback to the CRI
implementation if an "image not found" error is returned from the
containerd-native delete. This is typically only the case when passing
image identifiers (truncated or otherwise) incurs behavior equivalent to
`docker image rm --force --no-prune <image-id>`.

Fixes #7 

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
