### PR TITLE
pull: leverage local credentials

### DIFF
--- a/pkg/client/image/tag.go
+++ b/pkg/client/image/tag.go
@@ -36,7 +36,7 @@ func (s *Tag) Do(ctx context.Context, k8s *client.Interface, image string, tags 
 		if err != nil {
 			return err
 		}
-		logrus.Debugf("%#v", res)
+		logrus.Debugf("image-tag: %#v", res)
 		return nil
 	})
 }

--- a/pkg/server/images/images.go
+++ b/pkg/server/images/images.go
@@ -1,15 +1,20 @@
 package images
 
 import (
+	"fmt"
+	"net/http"
 	"sync"
 
-	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
 	buildkit "github.com/moby/buildkit/client"
 	imagesv1 "github.com/rancher/kim/pkg/apis/services/images/v1alpha1"
+	"github.com/rancher/kim/pkg/auth"
 	"github.com/rancher/kim/pkg/client"
+	"github.com/rancher/kim/pkg/version"
 	"github.com/sirupsen/logrus"
+	criv1 "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 var _ imagesv1.ImagesServer = &Server{}
@@ -45,4 +50,23 @@ func (s *Server) Close() {
 			logrus.Warnf("error closing connection to containerd: %v", err)
 		}
 	}
+}
+
+func Resolver(authConfig *criv1.AuthConfig, statusTracker docker.StatusTracker) remotes.Resolver {
+	authorizer := docker.NewDockerAuthorizer(
+		docker.WithAuthClient(http.DefaultClient),
+		docker.WithAuthCreds(func(host string) (string, string, error) {
+			return auth.Parse(authConfig, host)
+		}),
+		docker.WithAuthHeader(http.Header{
+			"User-Agent": []string{fmt.Sprintf("rancher-kim/%s", version.Version)},
+		}),
+	)
+	return docker.NewResolver(docker.ResolverOptions{
+		Tracker: statusTracker,
+		Hosts: docker.ConfigureDefaultRegistries(
+			docker.WithAuthorizer(authorizer),
+		),
+	})
+
 }


### PR DESCRIPTION
Pull will now leverage local credentials exclusively when fetching images.
    
Additionally, there is an option to specify that pull should use the CRI backend instead of containerd. This is passed through on the criv1.ImageSpec via annotations.
    
Platform can be specified when pulling and is passed into the containerd-pull backend via criv1.ImageSpec annotation.

Fixes #2 

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
