### PR TITLE
golang: default to 1.16 on alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.16-alpine
+ARG GOLANG=golang:1.16-alpine3.12
 FROM ${GOLANG} AS base
 RUN set -x \
  && apk --no-cache add \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GO_LDFLAGS += -X $(PKG)/pkg/version.Version=$(TAG)
 GO_LDFLAGS += -X $(PKG)/pkg/server.DefaultAgentImage=docker.io/$(ORG)/kim
 
 GO ?= go
-GOLANG ?= docker.io/library/golang:1.15-alpine
+GOLANG ?= golang:1.16-alpine3.12
 
 BIN ?= bin/kim
 ifeq ($(GOOS),windows)


### PR DESCRIPTION
Side-step a number of issues specific to the way we build with docker in drone.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
