### PR TITLE
ci: allow for cross-compilation build-args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,11 @@ RUN go generate -x
 ARG ORG=rancher
 ARG PKG=github.com/rancher/kim
 ARG TAG=0.0.0-dev+possible
-RUN make ORG=${ORG} PKG=${PKG} TAG=${TAG} bin/kim
+ARG GOOS=linux
+ARG GOARCH=amd64
+RUN make GOOS=${GOOS} GOARCH=${GOARCH} ORG=${ORG} PKG=${PKG} TAG=${TAG} bin/kim
 RUN file bin/kim
-RUN install -s bin/kim -m 0755 /usr/local/bin
+RUN install -s bin/kim -m 0755 /usr/local/bin || cp -vf bin/kim /usr/local/bin/
 
 FROM scratch AS release
 COPY --from=build /usr/local/bin/kim /bin/kim


### PR DESCRIPTION
Pass $GOOS and $GOARCH build args from Makefile, allowing for build
output from kim or buildkit to match the client platform as demonstrated
in the March 2021 Web Meetup: https://www.youtube.com/watch?v=QsV2IBAGEyY

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
