### PR TITLE
image: tagless images default to latest tag

### DIFF
--- a/pkg/client/image/pull.go
+++ b/pkg/client/image/pull.go
@@ -27,7 +27,7 @@ func (s *Pull) Do(ctx context.Context, k8s *client.Interface, image string) erro
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse image")
 	}
-	image = named.String()
+	image = reference.TagNameOnly(named).String()
 	return client.Images(ctx, k8s, func(ctx context.Context, imagesClient imagesv1.ImagesClient) error {
 		ch := make(chan []imagesv1.ImageStatus)
 		eg, ctx := errgroup.WithContext(ctx)

--- a/pkg/client/image/push.go
+++ b/pkg/client/image/push.go
@@ -24,7 +24,7 @@ func (s *Push) Do(ctx context.Context, k8s *client.Interface, image string) erro
 	if err != nil {
 		return errors.Wrap(err, "Failed to parse image")
 	}
-	image = named.String()
+	image = reference.TagNameOnly(named).String()
 	return client.Images(ctx, k8s, func(ctx context.Context, imagesClient imagesv1.ImagesClient) error {
 		ch := make(chan []imagesv1.ImageStatus)
 		eg, ctx := errgroup.WithContext(ctx)

--- a/pkg/client/image/remove.go
+++ b/pkg/client/image/remove.go
@@ -14,6 +14,9 @@ type Remove struct {
 }
 
 func (s *Remove) Do(ctx context.Context, k8s *client.Interface, image string) error {
+	if named, err := reference.ParseNormalizedNamed(image); err == nil {
+		image = reference.TagNameOnly(named).String()
+	}
 	return client.Images(ctx, k8s, func(ctx context.Context, imagesClient imagesv1.ImagesClient) error {
 		req := &imagesv1.ImageRemoveRequest{
 			Image: &criv1.ImageSpec{

--- a/pkg/client/image/tag.go
+++ b/pkg/client/image/tag.go
@@ -15,7 +15,7 @@ type Tag struct {
 
 func (s *Tag) Do(ctx context.Context, k8s *client.Interface, image string, tags []string) error {
 	if named, err := reference.ParseNormalizedNamed(image); err == nil {
-		image = named.String()
+		image = reference.TagNameOnly(named).String()
 	}
 	normalizedTags := make([]string, len(tags))
 	for i, tag := range tags {


### PR DESCRIPTION
Make sure that when referring to images we default to the "latest"
tag for tagless references for the following operations:
- push
- pull
- remove
- tag

Fixes #37

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
