### PR TITLE
main: fix kubectl-dropin on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,11 @@ image-manifest-all:
 drone-local:
 	DRONE_TAG=v0.0.0-dev.0+drone drone exec --trusted
 
-.PHONE: dogfood
+.PHONY: dogfood
 dogfood: build
 	DOCKER_IMAGE="./bin/kim image" make image
+
+.PHONY: symlinks
+symlinks: build
+	ln -nsf $(notdir $(BIN)) $(dir $(BIN))/kubectl-builder
+	ln -nsf $(notdir $(BIN)) $(dir $(BIN))/kubectl-image

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containerd/containerd/pkg/seed"
 	"github.com/rancher/kim/pkg/cli"
@@ -19,7 +20,7 @@ func init() {
 }
 
 func main() {
-	switch _, exe := filepath.Split(os.Args[0]); exe {
+	switch exe := strings.Split(filepath.Base(os.Args[0]), `.exe`)[0]; exe {
 	case "kubectl-builder":
 		command.Main(cli.Builder(exe))
 	case "kubectl-image":


### PR DESCRIPTION
Allow for the case, on windows, that the zeroth command-line argument
will have an `.exe` suffix when attempting to make the multi-call
disambiguation.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
