### PR TITLE
support kind clusters

### DIFF
--- a/pkg/server/agent_linux.go
+++ b/pkg/server/agent_linux.go
@@ -33,7 +33,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 	defer backend.Close()
 
-	go a.syncImageContent(namespaces.WithNamespace(ctx, a.BuildkitNamespace), backend.Containerd)
+	go a.syncImageContent(namespaces.WithNamespace(ctx, buildkitNamespace), backend.Containerd)
 	go a.listenAndServe(ctx, backend)
 
 	select {
@@ -94,7 +94,7 @@ func (a *Agent) syncImageContent(ctx context.Context, ctr *containerd.Client) {
 			if !ok {
 				return
 			}
-			if evt.Namespace != a.BuildkitNamespace {
+			if evt.Namespace != buildkitNamespace {
 				continue
 			}
 			if err := handleImageEvent(ctx, ctr, evt.Event); err != nil {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -20,6 +20,12 @@ const (
 	defaultAgentPort     = 1233
 	defaultAgentImage    = "docker.io/rancher/kim"
 	defaultBuildkitImage = "docker.io/moby/buildkit:v0.8.3"
+	buildkitNamespace    = "buildkit"
+
+	K3sContainerdSocket   = "/run/k3s/containerd/containerd.sock"
+	K3sContainerdVolume   = "/var/lib/rancher"
+	StockContainerdSocket = "/run/containerd/containerd.sock"
+	StockContainerdVolume = "/var/lib/containerd"
 )
 
 var (
@@ -29,13 +35,13 @@ var (
 )
 
 type Config struct {
-	AgentImage        string `usage:"Image to run the agent w/ missing tag inferred from version"`
-	AgentPort         int    `usage:"Port that the agent will listen on" default:"1233"`
-	BuildkitImage     string `usage:"BuildKit image for running buildkitd" default:"docker.io/moby/buildkit:v0.8.3"`
-	BuildkitNamespace string `usage:"BuildKit namespace in containerd (not 'k8s.io')" default:"buildkit"`
-	BuildkitPort      int    `usage:"BuildKit service port" default:"1234"`
-	BuildkitSocket    string `usage:"BuildKit socket address" default:"unix:///run/buildkit/buildkitd.sock"`
-	ContainerdSocket  string `usage:"Containerd socket address" default:"/run/k3s/containerd/containerd.sock"`
+	AgentImage       string `usage:"Image to run the agent w/ missing tag inferred from version"`
+	AgentPort        int    `usage:"Port that the agent will listen on" default:"1233"`
+	BuildkitImage    string `usage:"BuildKit image for running buildkitd" default:"docker.io/moby/buildkit:v0.8.3"`
+	BuildkitPort     int    `usage:"BuildKit service port" default:"1234"`
+	BuildkitSocket   string `usage:"BuildKit socket address" default:"unix:///run/buildkit/buildkitd.sock"`
+	ContainerdSocket string `usage:"Containerd socket address (default on k3s \"/run/k3s/containerd/containerd.sock\")"`
+	ContainerdVolume string `usage:"Containerd storage volume (default on k3s \"/var/lib/rancher\")"`
 }
 
 func (c *Config) GetAgentImage() (string, error) {
@@ -86,7 +92,7 @@ func (c *Config) Interface(ctx context.Context, config *client.Config) (*images.
 		return nil, err
 	}
 	server.Containerd, err = containerd.NewWithConn(conn,
-		containerd.WithDefaultNamespace(c.BuildkitNamespace),
+		containerd.WithDefaultNamespace(buildkitNamespace),
 		containerd.WithTimeout(5*time.Second),
 	)
 	if err != nil {


### PR DESCRIPTION
Before setting the node role assert that it is running a supported
container runtime, a.k.a "containerd", and auto-detect reasonable
defaults for the container socket and storage host path (parent).

Added `k3s builder install --containerd-volume` flag to support kind and
non-standard containerd installations.

Removed `k3s builder install --buildkit-namespace` flag (because it is
not something you can set on buildkitd).

Fixes #49

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
