### PR TITLE
builder: fix install panic

### DIFF
--- a/pkg/client/builder/install.go
+++ b/pkg/client/builder/install.go
@@ -483,6 +483,9 @@ func (a *Install) NodeRole(_ context.Context, k *client.Interface) error {
 	if err != nil {
 		return err
 	}
+	if len(nodeList.Items) == 0 {
+		return errors.New("failed to select any nodes")
+	}
 	if len(nodeList.Items) == 1 {
 		logrus.Infof("Applying node-role `builder` to `%s`", nodeList.Items[0].Name)
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {


### PR DESCRIPTION
Address the case where a too-narrow selector (or some other odd
conditions?) results in no nodes being selected during install.
This fix replaces the panic with an error message.

Fixes #60

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
