### PR TITLE
builder: add endpoint-addr flag to install

### DIFF
--- a/pkg/cli/command/builder/install/install.go
+++ b/pkg/cli/command/builder/install/install.go
@@ -8,11 +8,13 @@ import (
 )
 
 func Command() *cobra.Command {
-	return wrangler.Command(&CommandSpec{}, cobra.Command{
+	cmd := wrangler.Command(&CommandSpec{}, cobra.Command{
 		Use:                   "install [OPTIONS]",
 		Short:                 "Install builder component(s)",
 		DisableFlagsInUseLine: true,
 	})
+	cmd.Flag("endpoint-addr").Hidden = true // because the "hidden" annotation is not supported
+	return cmd
 }
 
 type CommandSpec struct {


### PR DESCRIPTION
Implement (hopefully, temporary) `endpoint-addr` flag when installing
the builder to allow for rancher desktop to configure the endpoint to
accomodate host-level port-forwarding to the guest vm.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
