### PR TITLE
image: honor global args

### DIFF
--- a/pkg/cli/command/image/build/build.go
+++ b/pkg/cli/command/image/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"os"
 
+	"github.com/rancher/kim/pkg/cli/command/builder/install"
 	"github.com/rancher/kim/pkg/client"
 	"github.com/rancher/kim/pkg/client/image"
 	wrangler "github.com/rancher/wrangler-cli"
@@ -36,6 +37,10 @@ func (c *CommandSpec) Run(cmd *cobra.Command, args []string) error {
 	if path == "" || path == "." {
 		path, err = os.Getwd()
 	}
+	if err != nil {
+		return err
+	}
+	err = install.Check(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/command/image/image.go
+++ b/pkg/cli/command/image/image.go
@@ -3,18 +3,14 @@ package image
 import (
 	"fmt"
 
-	"github.com/rancher/kim/pkg/cli/command/builder/install"
 	"github.com/rancher/kim/pkg/cli/command/image/build"
 	"github.com/rancher/kim/pkg/cli/command/image/list"
 	"github.com/rancher/kim/pkg/cli/command/image/pull"
 	"github.com/rancher/kim/pkg/cli/command/image/push"
 	"github.com/rancher/kim/pkg/cli/command/image/remove"
 	"github.com/rancher/kim/pkg/cli/command/image/tag"
-	"github.com/rancher/kim/pkg/client"
 	wrangler "github.com/rancher/wrangler-cli"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -44,25 +40,6 @@ func Command() *cobra.Command {
 }
 
 type CommandSpec struct {
-}
-
-func (s *CommandSpec) PersistentPre(cmd *cobra.Command, _ []string) error {
-	pre := install.CommandSpec{}
-	// i've tried using subcommands from the cli command tree but there be dragons
-	wrangler.Command(&pre, cobra.Command{}) // initialize pre.Install defaults
-	k8s, err := client.DefaultConfig.Interface()
-	if err != nil {
-		return err
-	}
-	// if the daemon-set is available then we don't need to do anything
-	daemon, err := k8s.Apps.DaemonSet().Get(k8s.Namespace, "builder", metav1.GetOptions{})
-	if err == nil && daemon.Status.NumberAvailable > 0 {
-		return nil
-	}
-	pre.NoWait = false
-	pre.NoFail = true
-	logrus.Warnf("Cannot find available builder daemon, attempting automatic installation...")
-	return pre.Install.Do(cmd.Context(), k8s)
 }
 
 func (s *CommandSpec) Run(cmd *cobra.Command, _ []string) error {

--- a/pkg/cli/command/image/list/list.go
+++ b/pkg/cli/command/image/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 
+	"github.com/rancher/kim/pkg/cli/command/builder/install"
 	"github.com/rancher/kim/pkg/client"
 	"github.com/rancher/kim/pkg/client/image"
 	wrangler "github.com/rancher/wrangler-cli"
@@ -32,6 +33,10 @@ type CommandSpec struct {
 
 func (s *CommandSpec) Run(cmd *cobra.Command, args []string) error {
 	k8s, err := client.DefaultConfig.Interface()
+	if err != nil {
+		return err
+	}
+	err = install.Check(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/command/image/pull/pull.go
+++ b/pkg/cli/command/image/pull/pull.go
@@ -1,6 +1,7 @@
 package pull
 
 import (
+	"github.com/rancher/kim/pkg/cli/command/builder/install"
 	"github.com/rancher/kim/pkg/client"
 	"github.com/rancher/kim/pkg/client/image"
 	wrangler "github.com/rancher/wrangler-cli"
@@ -27,6 +28,10 @@ type CommandSpec struct {
 
 func (s *CommandSpec) Run(cmd *cobra.Command, args []string) error {
 	k8s, err := client.DefaultConfig.Interface()
+	if err != nil {
+		return err
+	}
+	err = install.Check(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/command/image/push/push.go
+++ b/pkg/cli/command/image/push/push.go
@@ -1,6 +1,7 @@
 package push
 
 import (
+	"github.com/rancher/kim/pkg/cli/command/builder/install"
 	"github.com/rancher/kim/pkg/client"
 	"github.com/rancher/kim/pkg/client/image"
 	wrangler "github.com/rancher/wrangler-cli"
@@ -27,6 +28,10 @@ type CommandSpec struct {
 
 func (s *CommandSpec) Run(cmd *cobra.Command, args []string) error {
 	k8s, err := client.DefaultConfig.Interface()
+	if err != nil {
+		return err
+	}
+	err = install.Check(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/command/image/remove/remove.go
+++ b/pkg/cli/command/image/remove/remove.go
@@ -3,6 +3,7 @@ package remove
 import (
 	"fmt"
 
+	"github.com/rancher/kim/pkg/cli/command/builder/install"
 	"github.com/rancher/kim/pkg/client"
 	"github.com/rancher/kim/pkg/client/image"
 	wrangler "github.com/rancher/wrangler-cli"
@@ -33,6 +34,10 @@ type CommandSpec struct {
 
 func (c *CommandSpec) Run(cmd *cobra.Command, args []string) error {
 	k8s, err := client.DefaultConfig.Interface()
+	if err != nil {
+		return err
+	}
+	err = install.Check(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/command/image/tag/tag.go
+++ b/pkg/cli/command/image/tag/tag.go
@@ -1,6 +1,7 @@
 package tag
 
 import (
+	"github.com/rancher/kim/pkg/cli/command/builder/install"
 	"github.com/rancher/kim/pkg/client"
 	"github.com/rancher/kim/pkg/client/image"
 	wrangler "github.com/rancher/wrangler-cli"
@@ -27,6 +28,10 @@ type CommandSpec struct {
 
 func (c *CommandSpec) Run(cmd *cobra.Command, args []string) error {
 	k8s, err := client.DefaultConfig.Interface()
+	if err != nil {
+		return err
+	}
+	err = install.Check(cmd.Context())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Implement the default installation check/attempt as final check before
invoking each sub-command. This removes the `PersistentPre()` impl from
the `image.CommandSpec` unblocking the global `cli.App`#`PersistentPre()`.

Fixes #56 
Fixes #59 

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
