### PR TITLE
build: flag images for unpacking by default

### DIFF
--- a/pkg/client/image/build.go
+++ b/pkg/client/image/build.go
@@ -216,6 +216,7 @@ func (s *Build) defaultExporter() ([]buildkit.ExportEntry, error) {
 		}
 		exp.Attrs["name"] = strings.Join(tags, ",")
 		exp.Attrs["name-canonical"] = "" // true
+		exp.Attrs["unpack"] = "true"
 	}
 	return []buildkit.ExportEntry{exp}, nil
 }


### PR DESCRIPTION
Adjust the default buildkit output parameters to unpack built images.
This will trigger content updates after image creation which required a
modification to the image sync process that attempts to wait for
referenced content to be available before attempting the copy.

Fixes #74

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
