### PR TITLE
fix agent crash when removing invalid image

### DIFF
--- a/pkg/client/image/remove.go
+++ b/pkg/client/image/remove.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	imagesv1 "github.com/rancher/kim/pkg/apis/services/images/v1alpha1"
 	"github.com/rancher/kim/pkg/client"
 	"github.com/sirupsen/logrus"
@@ -16,6 +17,9 @@ func (s *Remove) Do(ctx context.Context, k8s *client.Interface, image string) er
 		ref, err := refSpec(ctx, imagesClient, image)
 		if err != nil {
 			return err
+		}
+		if ref == nil {
+			return errors.Errorf("image %q: not found", image)
 		}
 		res, err := imagesClient.Remove(ctx, &imagesv1.ImageRemoveRequest{Image: ref})
 		logrus.Debugf("%#v", res)

--- a/pkg/server/images/remove.go
+++ b/pkg/server/images/remove.go
@@ -19,6 +19,9 @@ func (s *Server) Remove(ctx context.Context, req *imagesv1.ImageRemoveRequest) (
 		return nil, err
 	}
 	defer done(ctx)
+	if req.Image == nil {
+		return &imagesv1.ImageRemoveResponse{}, nil
+	}
 	img, err := s.Containerd.ImageService().Get(ctx, req.Image.Image)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The client attempts to "noramlize" image refs when deleting to allow for
shortened image identifiers to be passed. When passing an invalid image
ref this could result in the client requesting deletion of a nil image
from the server. The server now silently succeed and do nothing while
the client now checks for passing a nil image ref and lets the user know
that no such image could be found.

Fixes #80

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
